### PR TITLE
Check for error when getting an access token from a refresh token.

### DIFF
--- a/src/main/java/com/nickdsantos/onedrive4j/OneDrive.java
+++ b/src/main/java/com/nickdsantos/onedrive4j/OneDrive.java
@@ -168,15 +168,21 @@ public class OneDrive {
 			HttpPost httpPost = new HttpPost(uri);
 			httpPost.setEntity(formEntity);
 
-			Map<Object, Object> rawToken = httpClient.execute(httpPost, new OneDriveJsonToMapResponseHandler());
-			if (rawToken != null) {
+			Map<Object, Object> rawResponse = httpClient.execute(httpPost, new OneDriveJsonToMapResponseHandler());
+
+			if (rawResponse.containsKey("error")) {
+				throw new IOException(rawResponse.get("error") + " : " +
+				                      rawResponse.get("error_description"));
+			}
+
+			if (rawResponse != null) {
 				accessToken = new AccessToken(
-						rawToken.get("token_type").toString(),
-						(int) Double.parseDouble(rawToken.get("expires_in").toString()),
-						rawToken.get("scope").toString(),
-						rawToken.get("access_token").toString(),
-						Objects.toString(rawToken.get("refresh_token"), null),
-						Objects.toString(rawToken.get("user_id"), null));
+						rawResponse.get("token_type").toString(),
+						(int) Double.parseDouble(rawResponse.get("expires_in").toString()),
+						rawResponse.get("scope").toString(),
+						rawResponse.get("access_token").toString(),
+						Objects.toString(rawResponse.get("refresh_token"), null),
+						Objects.toString(rawResponse.get("user_id"), null));
 			}
 		}
 

--- a/src/main/java/com/nickdsantos/onedrive4j/OneDrive.java
+++ b/src/main/java/com/nickdsantos/onedrive4j/OneDrive.java
@@ -170,12 +170,12 @@ public class OneDrive {
 
 			Map<Object, Object> rawResponse = httpClient.execute(httpPost, new OneDriveJsonToMapResponseHandler());
 
-			if (rawResponse.containsKey("error")) {
-				throw new IOException(rawResponse.get("error") + " : " +
-				                      rawResponse.get("error_description"));
-			}
-
 			if (rawResponse != null) {
+				if (rawResponse.containsKey("error")) {
+					throw new IOException(rawResponse.get("error") + " : " +
+							rawResponse.get("error_description"));
+				}
+
 				accessToken = new AccessToken(
 						rawResponse.get("token_type").toString(),
 						(int) Double.parseDouble(rawResponse.get("expires_in").toString()),


### PR DESCRIPTION
Checks for `"error"` key and throws `IOException` if it was set.
Format was based on what I saw in AlbumService (the only other place that seems to check for errors...)

Fixes issue #2.
