### PR TITLE
Swapping out Log4j 1.x with Slf4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,9 @@
       <version>2.5</version>
     </dependency>
 	<dependency>
-  	  <groupId>log4j</groupId>
-  	  <artifactId>log4j</artifactId>
-	  <version>1.2.17</version>
+  	  <groupId>org.slf4j</groupId>
+  	  <artifactId>slf4j-api</artifactId>
+	  <version>1.7.30</version>
   	</dependency>
   	<dependency>
   		<groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/com/nickdsantos/onedrive4j/AlbumService.java
+++ b/src/main/java/com/nickdsantos/onedrive4j/AlbumService.java
@@ -15,7 +15,8 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicHeader;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
@@ -31,7 +32,7 @@ import java.util.Map;
  *
  */
 public class AlbumService {
-	static Logger logger = Logger.getLogger(AlbumService.class.getName());		
+	static Logger logger = LoggerFactory.getLogger(AlbumService.class.getName());
 	
 	public static final String API_HOST = "apis.live.net/v5.0";
 	public static final String DEFAULT_SCHEME = "https";	

--- a/src/main/java/com/nickdsantos/onedrive4j/DriveService.java
+++ b/src/main/java/com/nickdsantos/onedrive4j/DriveService.java
@@ -9,7 +9,8 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,7 +25,7 @@ import java.util.*;
  * @author Luke Quinane
  */
 public class DriveService {
-    static Logger logger = Logger.getLogger(DriveService.class.getName());
+    static Logger logger = LoggerFactory.getLogger(DriveService.class.getName());
 
     public static final String API_HOST = "api.onedrive.com/v1.0";
     public static final String DEFAULT_SCHEME = "https";

--- a/src/main/java/com/nickdsantos/onedrive4j/OneDrive.java
+++ b/src/main/java/com/nickdsantos/onedrive4j/OneDrive.java
@@ -14,7 +14,8 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
@@ -29,7 +30,7 @@ import java.util.Objects;
  *
  */
 public class OneDrive {
-	static Logger logger = Logger.getLogger(OneDrive.class.getName());
+	static Logger logger = LoggerFactory.getLogger(OneDrive.class.getName());
 	
 	private static class AlbumServiceHolder {
 		public static AlbumService _albumServiceInstance = new AlbumService();

--- a/src/main/java/com/nickdsantos/onedrive4j/PhotoService.java
+++ b/src/main/java/com/nickdsantos/onedrive4j/PhotoService.java
@@ -16,7 +16,8 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicHeader;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
@@ -29,7 +30,7 @@ import java.util.*;
  *
  */
 public class PhotoService {
-	static Logger logger = Logger.getLogger(AlbumService.class.getName());		
+	static Logger logger = LoggerFactory.getLogger(AlbumService.class.getName());
 	
 	public static final String API_HOST = "apis.live.net/v5.0";
 	public static final String DEFAULT_SCHEME = "https";	


### PR DESCRIPTION
Log4j is end of life and contains security vulnerabilities.

The general recommendation for common logging APIs these days seems to be Slf4j, so this commit switches out the logging API dependency for slf4j-api.